### PR TITLE
Properly address #125

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,5 +14,5 @@ src/**
 .prettierrc.json
 
 # Python
-python/**
-!python/scripts/**.py
+python/*
+!python/scripts/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,13 +1,18 @@
-.vscode/**
-.vscode-test/**
-out/**
-src/**
+.github/
+.vscode/
+.vscode-test/
+node_modules/
+out/
+src/
 .gitignore
 .yarnrc
 **/tsconfig.json
 **/.eslintrc.json
 **/*.map
 **/*.ts
+
+# Husky
+.husky/
 
 # Prettier
 .prettierignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier": "^2.3.0",
         "ts-loader": "^9.2.2",
         "typescript": "^4.3.2",
-        "vsce": "~1.91.0",
+        "vsce": "^1.93.0",
         "vscode-test": "^1.5.0",
         "webpack": "^5.38.1",
         "webpack-cli": "^4.7.0"
@@ -4478,15 +4478,15 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
       "dependencies": {
-        "os-tmpdir": "~1.0.1"
+        "rimraf": "^3.0.0"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=8.17.0"
       }
     },
     "node_modules/to-fast-properties": {
@@ -4697,9 +4697,9 @@
       "dev": true
     },
     "node_modules/vsce": {
-      "version": "1.91.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.91.0.tgz",
-      "integrity": "sha512-y75QryWKzAw5KIR4NFEXc6XAy/Er1BHXdNwAESgKKFw8Yc8cA/+dP4Gj7VYhNPOJlV0v5j1in/cPkLFZAqC7cQ==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.93.0.tgz",
+      "integrity": "sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^10.2.2",
@@ -4708,16 +4708,16 @@
         "commander": "^6.1.0",
         "denodeify": "^1.2.1",
         "glob": "^7.0.6",
+        "ignore": "^5.1.8",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "markdown-it": "^10.0.0",
         "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
         "osenv": "^0.1.3",
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^5.1.0",
-        "tmp": "0.0.29",
+        "tmp": "^0.2.1",
         "typed-rest-client": "^1.8.4",
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
@@ -4778,6 +4778,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/vsce/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/vsce/node_modules/semver": {
@@ -8604,12 +8613,12 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "rimraf": "^3.0.0"
       }
     },
     "to-fast-properties": {
@@ -8774,9 +8783,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "1.91.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.91.0.tgz",
-      "integrity": "sha512-y75QryWKzAw5KIR4NFEXc6XAy/Er1BHXdNwAESgKKFw8Yc8cA/+dP4Gj7VYhNPOJlV0v5j1in/cPkLFZAqC7cQ==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.93.0.tgz",
+      "integrity": "sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^10.2.2",
@@ -8785,16 +8794,16 @@
         "commander": "^6.1.0",
         "denodeify": "^1.2.1",
         "glob": "^7.0.6",
+        "ignore": "^5.1.8",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "markdown-it": "^10.0.0",
         "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
         "osenv": "^0.1.3",
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^5.1.0",
-        "tmp": "0.0.29",
+        "tmp": "^0.2.1",
         "typed-rest-client": "^1.8.4",
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
@@ -8840,6 +8849,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         },
         "semver": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "^2.3.0",
     "ts-loader": "^9.2.2",
     "typescript": "^4.3.2",
-    "vsce": "~1.91.0",
+    "vsce": "^1.93.0",
     "vscode-test": "^1.5.0",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.0"


### PR DESCRIPTION
This PR should properly address issue #125 rather than simply downgrading vsce.

**Side notes**:
* Would it be acceptable to make some additional cleanups?
  * ie: the `**` is not needed at the end of things like `src/**` as the whole directory is ignored anyway.
* While doing this I noticed `.husky` is included in the final package. Is this intentional?