### PR TITLE
Use Python extension public API to get Python path

### DIFF
--- a/src/utils/python.ts
+++ b/src/utils/python.ts
@@ -1,27 +1,25 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { getActiveWorkspaceFolderPath, getExtensionPath } from './paths';
+import { getExtensionPath } from './paths';
 
 export async function resolvePythonScript(fileName: string) {
-  return `"${getPythonPath()}" "${getExtensionPath()}/python/scripts/${fileName}.py"`;
+  return `"${await getPythonInterpreterPath()}" "${getExtensionPath()}/python/scripts/${fileName}.py"`;
 }
 
-function getPythonPath() {
-  const pythonPath =
-    vscode.workspace.getConfiguration('python').get<string>('pythonPath') ??
-    'python';
-
-  // assume pythonPath is relative to workspace root.
-  const activeWorkspaceFolderPath = getActiveWorkspaceFolderPath();
-  if (!activeWorkspaceFolderPath) return pythonPath;
-  const relativePath = path.join(activeWorkspaceFolderPath, pythonPath);
-  if (fs.existsSync(relativePath)) return relativePath;
-  return pythonPath;
+async function getPythonInterpreterPath(): Promise<string> {
+  // Get path with the Python extension public API: https://github.com/microsoft/vscode-python/blob/main/src/client/api.ts#L135
+  const pythonExtensionApi = await vscode.extensions
+    .getExtension('ms-python.python')
+    ?.activate();
+  const pythonExecCommand =
+    pythonExtensionApi?.settings.getExecutionDetails().execCommand;
+  if (pythonExecCommand) return pythonExecCommand[0];
+  return 'python';
 }
 
 export async function installPythonPackage(pypiPackageName: string) {
   const terminal = vscode.window.createTerminal();
   terminal.show();
-  terminal.sendText(`"${getPythonPath()}" -m pip install ${pypiPackageName}`);
+  terminal.sendText(
+    `"${await getPythonInterpreterPath()}" -m pip install ${pypiPackageName}`
+  );
 }

--- a/src/utils/python.ts
+++ b/src/utils/python.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { NotFoundError } from './error';
 import { getExtensionPath } from './paths';
 
 export async function resolvePythonScript(fileName: string) {
@@ -13,7 +14,13 @@ async function getPythonInterpreterPath(): Promise<string> {
   const pythonExecCommand =
     pythonExtensionApi?.settings.getExecutionDetails().execCommand;
   if (pythonExecCommand) return pythonExecCommand[0];
-  return 'python';
+  const pythonDefaultInterpreter = vscode.workspace
+    .getConfiguration('python')
+    .get<string>('defaultInterpreterPath');
+  if (pythonDefaultInterpreter) return pythonDefaultInterpreter;
+  throw new NotFoundError(
+    'Python interpreter cannot could not be obtained from the Python extension.'
+  );
 }
 
 export async function installPythonPackage(pypiPackageName: string) {


### PR DESCRIPTION
As long as the public API of Python extension does not change, we should be able to get the correct tools from the Python virtual environment with PySide6 or PyQt6 installed.

Fix #151.
Fix #153.